### PR TITLE
Support C++ 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LUA_LIBNAME     = lua
 
 # Compiler
 CXX             ?= clang++
-USECXXFLAGS     += $(CXXFLAGS) -std=c++14 -O0 -g -DDEBUG -fmessage-length=0 -Wall -Wextra \
+USECXXFLAGS     += $(CXXFLAGS) -std=c++11 -O0 -g -DDEBUG -fmessage-length=0 -Wall -Wextra \
                    -pedantic -D_GLIBCXX_USE_C99 -Ilib -I$(LUA_INCDIR) -Ideps/catch/include
 USELDFLAGS      += $(LDFLAGS) -L$(LUA_LIBDIR)
 USELDLIBS       += $(LDLIBS) -lm -l$(LUA_LIBNAME) -ldl

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ point:x(4.2)
 ```
 
 ## Requirements
-You need a C++14-compliant compiler and at least Lua 5.1 to get this library to work. I recommend
+You need a C++11-compliant compiler and at least Lua 5.1 to get this library to work. I recommend
 using Lua 5.3 or later, to avoid the messy `lua_Integer` situation. LuaJIT 2.0 seems to work, apart
 from user types, which fail for yet unknown reasons.
 

--- a/lib/luwra/common.hpp
+++ b/lib/luwra/common.hpp
@@ -8,8 +8,8 @@
 #define LUWRA_COMMON_H_
 
 // Check C++ version
-#if !defined(__cplusplus) || __cplusplus < 201402L
-	#error You need a C++14 compliant compiler
+#if !defined(__cplusplus) || __cplusplus < 201103L
+	#error You need a C++11 compliant compiler
 #endif
 
 extern "C" {

--- a/lib/luwra/types.hpp
+++ b/lib/luwra/types.hpp
@@ -337,11 +337,27 @@ struct Value<Arbitrary> {
 };
 
 namespace internal {
+	template<size_t... Is>
+	struct index_sequence {};
+
+	template<size_t I, size_t... Is>
+	struct make_index_sequence_impl {
+		typedef typename make_index_sequence_impl<I - 1, I - 1, Is...>::type type;
+	};
+
+	template<size_t... Is>
+	struct make_index_sequence_impl<0, Is...> {
+		typedef index_sequence<Is...> type;
+	};
+
+	template<size_t I>
+	using make_index_sequence = typename make_index_sequence_impl<I>::type;
+
 	template <typename>
 	struct StackPusher;
 
 	template <size_t I>
-	struct StackPusher<std::index_sequence<I>> {
+	struct StackPusher<index_sequence<I>> {
 		template <typename... T> static inline
 		size_t push(State* state, const std::tuple<T...>& package) {
 			using R = typename std::tuple_element<I, std::tuple<T...>>::type;
@@ -350,12 +366,12 @@ namespace internal {
 	};
 
 	template <size_t I, size_t... Is>
-	struct StackPusher<std::index_sequence<I, Is...>> {
+	struct StackPusher<index_sequence<I, Is...>> {
 		template <typename... T> static inline
 		size_t push(State* state, const std::tuple<T...>& package) {
 			return
-				StackPusher<std::index_sequence<I>>::push(state, package)
-				+ StackPusher<std::index_sequence<Is...>>::push(state, package);
+				StackPusher<index_sequence<I>>::push(state, package)
+				+ StackPusher<index_sequence<Is...>>::push(state, package);
 		}
 	};
 }
@@ -367,7 +383,7 @@ template <typename... A>
 struct Value<std::tuple<A...>> {
 	static inline
 	size_t push(State* state, const std::tuple<A...>& value) {
-		return internal::StackPusher<std::make_index_sequence<sizeof...(A)>>::push(state, value);
+		return internal::StackPusher<internal::make_index_sequence<sizeof...(A)>>::push(state, value);
 	}
 };
 

--- a/lib/luwra/types.hpp
+++ b/lib/luwra/types.hpp
@@ -337,6 +337,7 @@ struct Value<Arbitrary> {
 };
 
 namespace internal {
+	// C++11 implementation of C++14's `index_sequence` and `make_index_sequence`.
 	template<size_t... Is>
 	struct index_sequence {};
 

--- a/lib/luwra/usertypes.hpp
+++ b/lib/luwra/usertypes.hpp
@@ -20,20 +20,23 @@ namespace internal {
 	using UserTypeID = const void*;
 
 	template <typename T>
-	using StripUserType = std::remove_cv_t<T>;
+	using StripUserType = typename std::remove_cv<T>::type;
 
 	/**
 	 * User type identifier
 	 */
-	template <typename T> extern
-	const UserTypeID user_type_id = (void*) INTPTR_MAX;
+	template <typename T>
+	UserTypeID user_type_id() {
+		return (void*) INTPTR_MAX;
+	}
 
 	/**
 	 * Registry name for a metatable which is associated with a user type
 	 */
-	template <typename T> extern
-	const std::string user_type_reg_name =
-		"UD#" + std::to_string(uintptr_t(&user_type_id<StripUserType<T>>));
+	template <typename T>
+	std::string user_type_reg_name() {
+		return "UD#" + std::to_string(uintptr_t(user_type_id<StripUserType<T>>()));
+	}
 
 	/**
 	 * Register a new metatable for a user type T.
@@ -41,7 +44,7 @@ namespace internal {
 	template <typename U> static inline
 	void new_user_type_metatable(State* state) {
 		using T = StripUserType<U>;
-		luaL_newmetatable(state, user_type_reg_name<T>.c_str());
+		luaL_newmetatable(state, user_type_reg_name<T>().c_str());
 	}
 
 	/**
@@ -50,7 +53,7 @@ namespace internal {
 	template <typename U> static inline
 	StripUserType<U>* check_user_type(State* state, int index) {
 		using T = StripUserType<U>;
-		return static_cast<T*>(luaL_checkudata(state, index, user_type_reg_name<T>.c_str()));
+		return static_cast<T*>(luaL_checkudata(state, index, user_type_reg_name<T>().c_str()));
 	}
 
 	/**
@@ -60,7 +63,7 @@ namespace internal {
 	void apply_user_type_meta_table(State* state) {
 		using T = StripUserType<U>;
 
-		luaL_getmetatable(state, user_type_reg_name<T>.c_str());
+		luaL_getmetatable(state, user_type_reg_name<T>().c_str());
 		lua_setmetatable(state, -2);
 	}
 
@@ -98,7 +101,7 @@ namespace internal {
 
 		return push(
 			state,
-			internal::user_type_reg_name<T>
+			internal::user_type_reg_name<T>()
 				+ "@"
 				+ std::to_string(uintptr_t(Value<T*>::read(state, 1)))
 		);

--- a/lib/luwra/usertypes.hpp
+++ b/lib/luwra/usertypes.hpp
@@ -17,7 +17,7 @@
 LUWRA_NS_BEGIN
 
 namespace internal {
-	using UserTypeID = const void*;
+	using UserTypeID = int;
 
 	template <typename T>
 	using StripUserType = typename std::remove_cv<T>::type;
@@ -28,7 +28,7 @@ namespace internal {
 	// In C++14 a template variable can be used instead of following.
 	template <typename T>
 	struct UserTypeIDWrapper {
-		static constexpr UserTypeID value = (void*) INTPTR_MAX;
+		static constexpr UserTypeID value = INT_MAX;
 	};
 	template <typename T>
 	constexpr UserTypeID UserTypeIDWrapper<T>::value;

--- a/lib/luwra/usertypes.hpp
+++ b/lib/luwra/usertypes.hpp
@@ -25,17 +25,20 @@ namespace internal {
 	/**
 	 * User type identifier
 	 */
+	// In C++14 a template variable can be used instead of following.
 	template <typename T>
-	UserTypeID user_type_id() {
-		return (void*) INTPTR_MAX;
-	}
+	struct UserTypeIDWrapper {
+		static constexpr UserTypeID value = (void*) INTPTR_MAX;
+	};
+	template <typename T>
+	constexpr UserTypeID UserTypeIDWrapper<T>::value;
 
 	/**
 	 * Registry name for a metatable which is associated with a user type
 	 */
 	template <typename T>
 	std::string user_type_reg_name() {
-		return "UD#" + std::to_string(uintptr_t(user_type_id<StripUserType<T>>()));
+		return "UD#" + std::to_string(uintptr_t(&UserTypeIDWrapper<StripUserType<T>>::value));
 	}
 
 	/**


### PR DESCRIPTION
Modified to be compliant with C++ 11. Tests are passed.

I admit this modification makes the code a little messy, but I think it is fairly reasonable. Dependency on C++ 14 have made projects reluctant to use luwra, for example tilemaker (https://github.com/systemed/tilemaker/issues/7).

One point alters the meaning of the code, while I'm not sure your original intention. So I'll comment there inline.