### PR TITLE
Compiles with VS 2015.2

### DIFF
--- a/lib/luwra/auxiliary.hpp
+++ b/lib/luwra/auxiliary.hpp
@@ -24,9 +24,9 @@ LUWRA_NS_BEGIN
 static inline
 bool equal(State* state, int index1, int index2) {
 #if LUA_VERSION_NUM <= 501
-	return lua_equal(state, index1, index2);
+	return lua_equal(state, index1, index2) == 1;
 #else
-	return lua_compare(state, index1, index2, LUA_OPEQ);
+	return lua_compare(state, index1, index2, LUA_OPEQ) == 1;
 #endif
 }
 

--- a/lib/luwra/common.hpp
+++ b/lib/luwra/common.hpp
@@ -7,11 +7,6 @@
 #ifndef LUWRA_COMMON_H_
 #define LUWRA_COMMON_H_
 
-// Check C++ version
-#if !defined(__cplusplus) || __cplusplus < 201103L
-	#error You need a C++11 compliant compiler
-#endif
-
 extern "C" {
 	#include <lua.h>
 	#include <lualib.h>

--- a/lib/luwra/functions.hpp
+++ b/lib/luwra/functions.hpp
@@ -26,7 +26,7 @@ namespace internal {
 	struct FunctionWrapper<R(A...)> {
 		template <R (* fun)(A...)> static inline
 		int invoke(State* state) {
-			return map<R(A...)>(state, fun);
+			return static_cast<int>(map<R(A...)>(state, fun));
 		}
 	};
 

--- a/lib/luwra/generic.hpp
+++ b/lib/luwra/generic.hpp
@@ -53,6 +53,10 @@ namespace internal {
 
 LUWRA_NS_END
 
+#ifdef _MSC_VER
+#define __STRING( x ) #x
+#endif // VC++ doesn't have __STRING
+
 /**
  * Generate a `lua_CFunction` wrapper for a field, method or function.
  * \returns Wrapped entity as `lua_CFunction`
@@ -67,6 +71,6 @@ LUWRA_NS_END
  * \returns `std::pair<const char*, CFunction>` which can be used to register a user type member
  */
 #define LUWRA_MEMBER(type, name) \
-	{__STRING(name), LUWRA_WRAP(type::name)}
+	{__STRING(name), LUWRA_WRAP(##type::##name)}
 
 #endif

--- a/lib/luwra/methods.hpp
+++ b/lib/luwra/methods.hpp
@@ -38,7 +38,7 @@ namespace internal {
 
 		template <MethodPointerType meth> static inline
 		int invoke(State* state) {
-			return map<FunctionSignature>(state, hook<meth>);
+			return static_cast<int>(map<FunctionSignature>(state, hook<meth>));
 		}
 	};
 
@@ -55,7 +55,7 @@ namespace internal {
 
 		template <MethodPointerType meth> static inline
 		int invoke(State* state) {
-			return map<FunctionSignature>(state, hook<meth>);
+			return static_cast<int>(map<FunctionSignature>(state, hook<meth>));
 		}
 	};
 
@@ -89,7 +89,7 @@ namespace internal {
 
 		template <MethodPointerType meth> static inline
 		int invoke(State* state) {
-			return map<FunctionSignature>(state, hook<meth>);
+			return static_cast<int>(map<FunctionSignature>(state, hook<meth>));
 		}
 	};
 }

--- a/lib/luwra/tables.hpp
+++ b/lib/luwra/tables.hpp
@@ -71,10 +71,10 @@ struct Table {
 		push(state, ref);
 
 		size_t pushedKeys = push(state, key);
-		if (pushedKeys > 1) lua_pop(state, pushedKeys - 1);
+		if (pushedKeys > 1) lua_pop(state, static_cast<int>(pushedKeys - 1));
 
 		size_t pushedValues = push(state, value);
-		if (pushedValues > 1) lua_pop(state, pushedValues - 1);
+		if (pushedValues > 1) lua_pop(state, static_cast<int>(pushedValues - 1));
 
 		lua_rawset(state, -3);
 		lua_pop(state, 1);
@@ -87,7 +87,7 @@ struct Table {
 		push(state, ref);
 
 		size_t pushedKeys = push(state, key);
-		if (pushedKeys > 1) lua_pop(state, pushedKeys - 1);
+		if (pushedKeys > 1) lua_pop(state, static_cast<int>(pushedKeys - 1));
 
 		lua_rawget(state, -2);
 		V ret = read<V>(state, -1);

--- a/lib/luwra/types.hpp
+++ b/lib/luwra/types.hpp
@@ -96,18 +96,33 @@ T read(State* state, int index) {
  * extracts it from the stack and a `pushf(State*, type)` which pushes the value on the stack again.
  * This assumes that only one value will be pushed onto the stack.
  */
-#define LUWRA_DEF_VALUE(type, retrf, pushf)                          \
-	template <>                                                      \
-	struct Value<type> {                                             \
+#define LUWRA_DEF_VALUE(type, retrf, pushf)                            \
+	template <>                                                       \
+	struct Value<type> {                                              \
 		static inline                                                \
 		type read(State* state, int n) {                             \
-			return retrf(state, n);                                  \
+			return static_cast<type>(retrf(state, n));              \
 		}                                                            \
-                                                                     \
+                                                                       \
 		static inline                                                \
 		size_t push(State* state, type value) {                      \
-			pushf(state, value);                                     \
-			return 1;                                                \
+			pushf(state, value);                                    \
+			return 1;                                               \
+		}                                                            \
+	}
+
+#define LUWRA_DEF_VALUE_BOOL(type, retrf, pushf)                       \
+	template <>                                                       \
+	struct Value<type> {                                              \
+		static inline                                                \
+		type read(State* state, int n) {                             \
+			return retrf(state, n) == 1;              \
+		}                                                            \
+                                                                       \
+		static inline                                                \
+		size_t push(State* state, type value) {                      \
+			pushf(state, value);                                    \
+			return 1;                                               \
 		}                                                            \
 	}
 
@@ -215,7 +230,7 @@ LUWRA_DEF_NUMERIC(Integer, signed   long long int)
 LUWRA_DEF_NUMERIC(Integer, unsigned long long int)
 
 // C/C++ types
-LUWRA_DEF_VALUE(bool,        luaL_checkboolean, lua_pushboolean);
+LUWRA_DEF_VALUE_BOOL(bool,   luaL_checkboolean, lua_pushboolean);
 LUWRA_DEF_VALUE(const char*, luaL_checkstring,  lua_pushstring);
 LUWRA_DEF_VALUE(std::string, luaL_checkstring,  luaL_pushstdstring);
 


### PR DESCRIPTION
I am [benchmarking your framework](https://github.com/ThePhD/lua-bench). It did not build with VS 2015 Update 2. I added these changes for a no-errors, warningless build for VC++, as far as my use cases were concerned.