### PR TITLE
Fixed metatable names not being unique for different user types in Release with VS2019

### DIFF
--- a/lib/luwra/usertypes.hpp
+++ b/lib/luwra/usertypes.hpp
@@ -24,17 +24,10 @@ namespace internal {
 	// User type registry identifiers
 	template <typename UserType>
 	struct UserTypeReg {
-		// Dummy field which is used because it has a seperate address for each instance of UserType
-		static
-		const int id;
-
 		// Registry name for a metatable which is associated with a user type
 		static
 		const std::string name;
 	};
-
-	template <typename UserType>
-	const int UserTypeReg<UserType>::id = INT_MAX;
 
 	#ifndef LUWRA_REGISTRY_PREFIX
 		#define LUWRA_REGISTRY_PREFIX "Luwra#"
@@ -42,7 +35,7 @@ namespace internal {
 
 	template <typename UserType>
 	const std::string UserTypeReg<UserType>::name =
-		LUWRA_REGISTRY_PREFIX + std::to_string(uintptr_t(&id));
+		LUWRA_REGISTRY_PREFIX + std::to_string(uintptr_t(&name));
 
 	template <typename UserType>
 	struct UserTypeWrapper: UserTypeReg<StripUserType<UserType>> {

--- a/tests/usertypes.cpp
+++ b/tests/usertypes.cpp
@@ -171,3 +171,40 @@ TEST_CASE("UserTypeGarbageCollectionRef") {
 	lua_close(state);
 	REQUIRE(shared_var.use_count() == 1);
 }
+
+TEST_CASE("UserTypeUniqueMetatables") {
+	luwra::StateWrapper state;
+	state.loadStandardLibrary();
+
+	// Registration
+	state.registerUserType<B>(
+		{
+			LUWRA_MEMBER(B, n),
+			LUWRA_MEMBER(B, cn),
+			LUWRA_MEMBER(B, vn),
+			LUWRA_MEMBER(B, cvn)
+		}
+	);
+
+	state.registerUserType<C>(
+		{
+			LUWRA_MEMBER(C, foo1),
+			LUWRA_MEMBER(C, foo2),
+			LUWRA_MEMBER(C, foo3),
+			LUWRA_MEMBER(C, foo4)
+		}
+	);
+
+	// Construct types to compare metatables
+	luwra::construct<B>(state, 1337);
+	lua_setglobal(state, "type_b");
+
+	luwra::construct<C>(state, 1337);
+	lua_setglobal(state, "type_c");
+
+	state.runString("return getmetatable(type_b) ~= getmetatable(type_c)");
+
+	// Check metatables are unique
+	REQUIRE(state.read<bool>(-1));
+}
+


### PR DESCRIPTION
_UserTypeReg<UserType>::name_ is now generated using the address of name itself rather than the address of a dummy _int id_ to avoid metatables having the same names due to optimisations in Release mode with Visual Studio 2019 causing every _id_ to have the same address. 

I have also added a test as requested to ensure the metatables are unique by comparing the result of getmetatable on two user types.